### PR TITLE
Add git methods to `Catalog`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ astrocats.egg-info/
 wiki
 blackholes
 ads.key
+test-input/
+test-output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ script:
     - coverage run -a -m astrocats catalog import -a --task-groups meta
     - coverage run -a -m astrocats catalog analyze -v --count
     - echo "travis_fold:end:IMPORT Importing data done"
-    - echo "travis_fold:start:GIT checking git repos"
-    - coverage run -a -m astrocats catalog git-status
-    - coverage run -a -m astrocats catalog git-reset-local
-    - coverage run -a -m astrocats catalog git-status
-    - coverage run -a -m astrocats catalog git-reset-origin
-    - coverage run -a -m astrocats catalog git-push
-    - echo "travis_fold:end:GIT completed git checks"
+    # - echo "travis_fold:start:GIT checking git repos"
+    # - coverage run -a -m astrocats catalog git-status
+    # - coverage run -a -m astrocats catalog git-reset-local
+    # - coverage run -a -m astrocats catalog git-status
+    # - coverage run -a -m astrocats catalog git-reset-origin
+    # - coverage run -a -m astrocats catalog git-push
+    # - echo "travis_fold:end:GIT completed git checks"
 #    - echo "travis_fold:start:MAKE Making catalog"
 #    - cd astrocats/supernovae/scripts
 #    - python make-catalog.py -tr

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
     - coverage run -a -m astrocats catalog git-reset-local
     - coverage run -a -m astrocats catalog git-status
     - coverage run -a -m astrocats catalog git-reset-origin
-    - coverage run -a -m astrocats catalog git-push
+#    - coverage run -a -m astrocats catalog git-push
     - echo "travis_fold:end:GIT completed git checks"
 #    - echo "travis_fold:start:MAKE Making catalog"
 #    - cd astrocats/supernovae/scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ script:
     - coverage run -a -m astrocats catalog import -a --task-groups meta
     - coverage run -a -m astrocats catalog analyze -v --count
     - echo "travis_fold:end:IMPORT Importing data done"
-    # - echo "travis_fold:start:GIT checking git repos"
-    # - coverage run -a -m astrocats catalog git-status
-    # - coverage run -a -m astrocats catalog git-reset-local
-    # - coverage run -a -m astrocats catalog git-status
-    # - coverage run -a -m astrocats catalog git-reset-origin
-    # - coverage run -a -m astrocats catalog git-push
-    # - echo "travis_fold:end:GIT completed git checks"
+    - echo "travis_fold:start:GIT checking git repos"
+    - coverage run -a -m astrocats catalog git-status
+    - coverage run -a -m astrocats catalog git-reset-local
+    - coverage run -a -m astrocats catalog git-status
+    - coverage run -a -m astrocats catalog git-reset-origin
+    - coverage run -a -m astrocats catalog git-push
+    - echo "travis_fold:end:GIT completed git checks"
 #    - echo "travis_fold:start:MAKE Making catalog"
 #    - cd astrocats/supernovae/scripts
 #    - python make-catalog.py -tr

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,13 @@ script:
     - coverage run -a -m astrocats catalog import -a --task-groups meta
     - coverage run -a -m astrocats catalog analyze -v --count
     - echo "travis_fold:end:IMPORT Importing data done"
+    - echo "travis_fold:start:GIT checking git repos"
+    - coverage run -a -m astrocats catalog git-status
+    - coverage run -a -m astrocats catalog git-reset-local
+    - coverage run -a -m astrocats catalog git-status
+    - coverage run -a -m astrocats catalog git-reset-origin
+    - coverage run -a -m astrocats catalog git-push
+    - echo "travis_fold:end:GIT completed git checks"
 #    - echo "travis_fold:start:MAKE Making catalog"
 #    - cd astrocats/supernovae/scripts
 #    - python make-catalog.py -tr

--- a/astrocats/catalog/argshandler.py
+++ b/astrocats/catalog/argshandler.py
@@ -25,13 +25,17 @@ class ArgsHandler:
             catalog.git_add_commit_push_all_repos()
         elif args.subcommand == 'git-pull':
             self.log.info("Running 'git pull'.")
-            catalog.git_add_commit_push_all_repos()
-        elif args.subcommand == 'git-reset':
-            self.log.info("Running 'git reset'.")
-            catalog.git_add_commit_push_all_repos()
+            # catalog.git_pull_all_repos()
+            raise RuntimeError("NOT YET IMPLEMENTED!")
+        elif args.subcommand == 'git-reset-local':
+            self.log.info("Running 'git reset' using the local HEAD.")
+            catalog.git_reset_all_repos(hard=True, origin=False, clean=True)
+        elif args.subcommand == 'git-reset-origin':
+            self.log.info("Running 'git reset' using 'origin/master'.")
+            catalog.git_reset_all_repos(hard=True, origin=True, clean=True)
         elif args.subcommand == 'git-status':
             self.log.info("Running 'git status'.")
-            catalog.git_add_commit_push_all_repos()
+            # catalog.git_add_commit_push_all_repos()
 
         # Analyze Catalogs
         # ----------------
@@ -75,14 +79,7 @@ class ArgsHandler:
 
         # Git Subcommands
         # ---------------
-        # git-push
-        self._add_parser_arguments_git_push(subparsers)
-        # git-push
-        self._add_parser_arguments_git_pull(subparsers)
-        # git-push
-        self._add_parser_arguments_git_reset(subparsers)
-        # git-push
-        self._add_parser_arguments_git_status(subparsers)
+        self._add_parser_arguments_git(subparsers)
 
         # Analyze Catalogs
         # ----------------
@@ -144,41 +141,30 @@ class ArgsHandler:
 
         return import_pars
 
-    def _add_parser_arguments_git_push(self, subparsers):
-        """Create a parser for the 'git-push' subcommand.
+    def _add_parser_arguments_git(self, subparsers):
+        """Create a sub-parsers for git subcommands.
         """
-        push_pars = subparsers.add_parser(
+        subparsers.add_parser(
             "git-push",
             help="Add all files to data repositories, commit, and push.")
 
-        return push_pars
-
-    def _add_parser_arguments_git_pull(self, subparsers):
-        """Create a parser for the 'git-pull' subcommand.
-        """
-        pull_pars = subparsers.add_parser(
+        subparsers.add_parser(
             "git-pull",
             help="'Pull' all data repositories.")
 
-        return pull_pars
+        subparsers.add_parser(
+            "git-reset-local",
+            help="Hard reset all data repositories using local 'HEAD'.")
 
-    def _add_parser_arguments_git_reset(self, subparsers):
-        """Create a parser for the 'git-reset' subcommand.
-        """
-        reset_pars = subparsers.add_parser(
-            "git-reset",
-            help="Hard reset all data repositories.")
+        subparsers.add_parser(
+            "git-reset-origin",
+            help="Hard reset all data repositories using 'origin/master'.")
 
-        return reset_pars
-
-    def _add_parser_arguments_git_status(self, subparsers):
-        """Create a parser for the 'git-status' subcommand.
-        """
-        status_pars = subparsers.add_parser(
+        subparsers.add_parser(
             "git-status",
             help="Get the 'git status' of all data repositories.")
 
-        return status_pars
+        return
 
     def _add_parser_arguments_analyze(self, subparsers):
         """Create a parser for the 'analyze' subcommand.

--- a/astrocats/catalog/argshandler.py
+++ b/astrocats/catalog/argshandler.py
@@ -12,12 +12,29 @@ class ArgsHandler:
         return
 
     def run_subcommand(self, args, catalog):
+        # Data Import
+        # -----------
         if args.subcommand == 'import':
             self.log.info("Running 'import'.")
             catalog.import_data()
-        elif args.subcommand == 'push':
-            self.log.info("Running 'push'.")
+
+        # Git Subcommands
+        # ---------------
+        elif args.subcommand == 'git-push':
+            self.log.info("Running 'git push'.")
             catalog.git_add_commit_push_all_repos()
+        elif args.subcommand == 'git-pull':
+            self.log.info("Running 'git pull'.")
+            catalog.git_add_commit_push_all_repos()
+        elif args.subcommand == 'git-reset':
+            self.log.info("Running 'git reset'.")
+            catalog.git_add_commit_push_all_repos()
+        elif args.subcommand == 'git-status':
+            self.log.info("Running 'git status'.")
+            catalog.git_add_commit_push_all_repos()
+
+        # Analyze Catalogs
+        # ----------------
         elif args.subcommand == 'analyze':
             self.log.info("Running 'analyze'.")
             from .analysis import Analysis
@@ -51,10 +68,24 @@ class ArgsHandler:
         subparsers = parser.add_subparsers(
             description='valid subcommands', dest='subcommand')
 
+        # Data Import
+        # -----------
         # Add the 'import' command, and related arguments
         self._add_parser_arguments_import(subparsers)
-        # Add the 'push' command, and related arguments
-        self._add_parser_arguments_push(subparsers)
+
+        # Git Subcommands
+        # ---------------
+        # git-push
+        self._add_parser_arguments_git_push(subparsers)
+        # git-push
+        self._add_parser_arguments_git_pull(subparsers)
+        # git-push
+        self._add_parser_arguments_git_reset(subparsers)
+        # git-push
+        self._add_parser_arguments_git_status(subparsers)
+
+        # Analyze Catalogs
+        # ----------------
         # Add the 'analyze' command, and related arguments
         self._add_parser_arguments_analyze(subparsers)
 
@@ -113,14 +144,41 @@ class ArgsHandler:
 
         return import_pars
 
-    def _add_parser_arguments_push(self, subparsers):
-        """Create a parser for the 'import' subcommand.
+    def _add_parser_arguments_git_push(self, subparsers):
+        """Create a parser for the 'git-push' subcommand.
         """
         push_pars = subparsers.add_parser(
-            "push",
+            "git-push",
             help="Add all files to data repositories, commit, and push.")
 
         return push_pars
+
+    def _add_parser_arguments_git_pull(self, subparsers):
+        """Create a parser for the 'git-pull' subcommand.
+        """
+        pull_pars = subparsers.add_parser(
+            "git-pull",
+            help="'Pull' all data repositories.")
+
+        return pull_pars
+
+    def _add_parser_arguments_git_reset(self, subparsers):
+        """Create a parser for the 'git-reset' subcommand.
+        """
+        reset_pars = subparsers.add_parser(
+            "git-reset",
+            help="Hard reset all data repositories.")
+
+        return reset_pars
+
+    def _add_parser_arguments_git_status(self, subparsers):
+        """Create a parser for the 'git-status' subcommand.
+        """
+        status_pars = subparsers.add_parser(
+            "git-status",
+            help="Get the 'git status' of all data repositories.")
+
+        return status_pars
 
     def _add_parser_arguments_analyze(self, subparsers):
         """Create a parser for the 'analyze' subcommand.

--- a/astrocats/catalog/argshandler.py
+++ b/astrocats/catalog/argshandler.py
@@ -20,6 +20,9 @@ class ArgsHandler:
 
         # Git Subcommands
         # ---------------
+        elif args.subcommand == 'git-clone':
+            self.log.info("Running 'git clone'.")
+            catalog.git_clone_all_repos()
         elif args.subcommand == 'git-push':
             self.log.info("Running 'git push'.")
             catalog.git_add_commit_push_all_repos()
@@ -144,6 +147,10 @@ class ArgsHandler:
     def _add_parser_arguments_git(self, subparsers):
         """Create a sub-parsers for git subcommands.
         """
+        subparsers.add_parser(
+            "git-clone",
+            help="Clone all defined data repositories if they dont exist.")
+
         subparsers.add_parser(
             "git-push",
             help="Add all files to data repositories, commit, and push.")

--- a/astrocats/catalog/argshandler.py
+++ b/astrocats/catalog/argshandler.py
@@ -35,7 +35,7 @@ class ArgsHandler:
             catalog.git_reset_all_repos(hard=True, origin=True, clean=True)
         elif args.subcommand == 'git-status':
             self.log.info("Running 'git status'.")
-            # catalog.git_add_commit_push_all_repos()
+            catalog.git_status_all_repos()
 
         # Analyze Catalogs
         # ----------------

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -134,7 +134,7 @@ class Catalog:
             repo_folders += self.repos_dict['internal']
             repo_folders = list(sorted(set(repo_folders)))
             repo_folders = [os.path.join(self.PATH_INPUT, rf)
-                            for rf in repo_folders]
+                            for rf in repo_folders if len(rf)]
             return repo_folders
 
         def get_repo_output_file_list(self, normal=True, bones=True):
@@ -156,7 +156,7 @@ class Catalog:
             repo_folders = list(sorted(list(set(repo_folders)),
                                        key=lambda key: repo_priority(key)))
             repo_folders = [os.path.join(self.PATH_OUTPUT, rf)
-                            for rf in repo_folders]
+                            for rf in repo_folders if len(rf)]
             return repo_folders
 
     class SCHEMA:

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -482,6 +482,8 @@ class Catalog:
         """Perform a 'git pull' in each data repository.
 
         """
+        raise RuntimeError("THIS DOESNT WORK YET!")
+
         all_repos = self.PATHS.get_all_repo_folders()
         for repo in all_repos:
             self.log.warning("Repo in: '{}'".format(repo))
@@ -513,6 +515,10 @@ class Catalog:
             self.log.debug("Current SHA: '{}'".format(sha_beg))
 
             grepo = git.cmd.Git(repo)
+            # Fetch first
+            self.log.debug("fetching")
+            grepo.fetch()
+
             args = []
             if hard:
                 args.append('--hard')
@@ -526,7 +532,8 @@ class Catalog:
             # Clean
             if clean:
                 self.log.debug("cleaning")
-                retval = grepo.clean('-df')
+                # [q]uiet, [f]orce, [d]irectories
+                retval = grepo.clean('-qdf')
                 if len(retval):
                     self.log.warning("Git says: '{}'".format(retval))
 

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -174,7 +174,8 @@ class Catalog:
 
         # Load repos dictionary (required)
         self.repos_dict = read_json_dict(self.PATHS.REPOS_LIST)
-        self.clone_repos()
+        # self.clone_repos()
+        self.git_clone_all_repos()
 
         # Create empty `entries` collection
         self.entries = OrderedDict()
@@ -392,38 +393,6 @@ class Catalog:
     def save_caches(self):
         return
 
-    def _clone_repos(self, all_repos):
-        """Given a list of repositories, make sure they're all cloned.
-
-        Should be called from the subclassed `Catalog` objects, passed a list
-        of specific repository names.
-
-        Arguments
-        ---------
-        all_repos : list of str
-            *Absolute* path specification of each target repository.
-
-        """
-        for repo in all_repos:
-            if not os.path.isdir(repo):
-                try:
-                    repo_name = os.path.split(repo)[-1]
-                    self.log.warning(
-                        'Cloning "' + repo + '" (only needs to be done ' +
-                        'once, may take few minutes per repo).')
-                    Repo.clone_from("https://github.com/astrocatalogs/" +
-                                    repo_name + ".git", repo,
-                                    **({'depth': self.args.clone_depth} if
-                                       self.args.clone_depth > 0 else {}))
-                except:
-                    self.log.error("CLONING '{}' INTERRUPTED".format(repo))
-                    raise
-
-        return
-
-    def clone_repos(self):
-        self._clone_repos([])
-
     def git_add_commit_push_all_repos(self):
         """Add all files in each data repository tree, commit, push.
 
@@ -499,6 +468,32 @@ class Catalog:
             sha_end = subprocess.getoutput(git_command)
             if sha_end != sha_beg:
                 self.log.info("Updated SHA: '{}'".format(sha_end))
+
+        return
+
+    def git_clone_all_repos(self):
+        """Perform a 'git clone' for each data repository that doesnt exist.
+        """
+        all_repos = self.PATHS.get_all_repo_folders()
+        for repo in all_repos:
+            self.log.warning("Repo in: '{}'".format(repo))
+
+            if os.path.isdir(repo):
+                self.log.info("Directory exists.")
+            else:
+                _clone_astrocats_repo(repo, self.log, depth=self.args.clone_depth)
+
+            grepo = git.cmd.Git(repo)
+            try:
+                grepo.status()
+            except git.GitCommandError:
+                self.log.error("Repository does not exist!")
+                raise
+
+            # Get the initial git SHA
+            git_command = "git rev-parse HEAD {}".format(repo)
+            sha_beg = subprocess.getoutput(git_command)
+            self.log.debug("Current SHA: '{}'".format(sha_beg))
 
         return
 
@@ -1202,3 +1197,33 @@ def _call_command_in_repo(comm, repo, log, fail=False, log_flag=True):
     if fail:
         retval.check_returncode()
     return
+
+
+def _clone_astrocats_repo(repo, log, depth=1):
+    """Given a list of repositories, make sure they're all cloned.
+
+    Should be called from the subclassed `Catalog` objects, passed a list
+    of specific repository names.
+
+    Arguments
+    ---------
+    all_repos : list of str
+        *Absolute* path specification of each target repository.
+
+    """
+    kwargs = {}
+    if depth > 0:
+        kwargs['depth'] = depth
+
+    try:
+        repo_name = os.path.split(repo)[-1]
+        repo_name = "https://github.com/astrocatalogs/" + repo_name + ".git"
+        log.warning(
+            "Cloning '{}' (only needs to be done ".format(repo) +
+            "once, may take few minutes per repo).")
+        grepo = git.Repo.clone_from(repo_name, repo, **kwargs)
+    except:
+        log.error("CLONING '{}' INTERRUPTED".format(repo))
+        raise
+
+    return grepo

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1183,14 +1183,15 @@ def _call_command_in_repo(comm, repo, log, fail=False, log_flag=True):
     """
     if log_flag:
         log.debug("Running '{}'.".format(" ".join(comm)))
-    retval = subprocess.call(comm, cwd=repo, stdout=subprocess.PIPE,
-                             stderr=subprocess.PIPE)
-    if retval.stderr is not None:
-        err_msg = retval.stderr.decode('ascii').strip().splitlines()
+    process = subprocess.Popen(comm, cwd=repo, stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    (stdout, stderr) = process.communicate()
+    if stderr is not None:
+        err_msg = stderr.decode('ascii').strip().splitlines()
         for em in err_msg:
             log.error(em)
-    if retval.stdout is not None:
-        out_msg = retval.stdout.decode('ascii').strip().splitlines()
+    if stdout is not None:
+        out_msg = stdout.decode('ascii').strip().splitlines()
         for om in out_msg:
             log.warning(om)
     # Raises an error if the command failed.

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -543,6 +543,33 @@ class Catalog:
 
         return
 
+    def git_status_all_repos(self, hard=True, origin=False, clean=True):
+        """Perform a 'git pull' in each data repository.
+
+        """
+        all_repos = self.PATHS.get_all_repo_folders()
+        for repo in all_repos:
+            self.log.warning("Repo in: '{}'".format(repo))
+            # Get the initial git SHA
+            git_command = "git rev-parse HEAD {}".format(repo)
+            sha_beg = subprocess.getoutput(git_command)
+            self.log.debug("Current SHA: '{}'".format(sha_beg))
+
+            grepo = git.cmd.Git(repo)
+            # Fetch first
+            self.log.debug("fetching")
+            grepo.fetch()
+
+            git_comm = ["git", "status"]
+            _call_command_in_repo(git_comm, repo, self.log,
+                                  fail=True, log_flag=True)
+
+            sha_end = subprocess.getoutput(git_command)
+            if sha_end != sha_beg:
+                self.log.info("Updated SHA: '{}'".format(sha_end))
+
+        return
+
     def load_entry_from_name(self, name, delete=True, merge=True):
         loaded_entry = self.proto.init_from_file(self, name=name, merge=merge)
         if loaded_entry is not None:

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1197,7 +1197,7 @@ def _call_command_in_repo(comm, repo, log, fail=False, log_flag=True):
     if retval.stdout is not None:
         out_msg = retval.stdout.decode('ascii').strip().splitlines()
         for om in out_msg:
-            log.info(om)
+            log.warning(om)
     # Raises an error if the command failed.
     if fail:
         retval.check_returncode()

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1183,8 +1183,8 @@ def _call_command_in_repo(comm, repo, log, fail=False, log_flag=True):
     """
     if log_flag:
         log.debug("Running '{}'.".format(" ".join(comm)))
-    retval = subprocess.run(comm, cwd=repo, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+    retval = subprocess.call(comm, cwd=repo, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
     if retval.stderr is not None:
         err_msg = retval.stderr.decode('ascii').strip().splitlines()
         for em in err_msg:

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1196,7 +1196,8 @@ def _call_command_in_repo(comm, repo, log, fail=False, log_flag=True):
             log.warning(om)
     # Raises an error if the command failed.
     if fail:
-        retval.check_returncode()
+        if process.returncode:
+            raise CalledProcessError
     return
 
 

--- a/astrocats/catalog/input/repos.json
+++ b/astrocats/catalog/input/repos.json
@@ -1,6 +1,6 @@
 {
     "output":[
-        ""
+        "test-output"
     ],
     "boneyard":[
         ""
@@ -9,6 +9,6 @@
         ""
     ],
     "internal":[
-        ""
+        "test-input"
     ]
 }

--- a/astrocats/catalog/input/repos.json
+++ b/astrocats/catalog/input/repos.json
@@ -1,6 +1,6 @@
 {
     "output":[
-        "test-output"
+        "catalog-test-output"
     ],
     "boneyard":[
         ""
@@ -9,6 +9,6 @@
         ""
     ],
     "internal":[
-        "test-input"
+        "catalog-test-input"
     ]
 }

--- a/astrocats/catalog/input/tasks.json
+++ b/astrocats/catalog/input/tasks.json
@@ -6,7 +6,7 @@
         "module": "catalog.tasks.test",
         "function": "do_test",
         "groups": ["meta"],
-        "repo": "input/catalog-test",
+        "repo": "input/test-input",
         "always_journal": true,
         "priority": 1
     },


### PR DESCRIPTION
There are now builtin methods which handle standard git commands, for _all_ data repositories (input and output).
- Push
- Status
- Reset, both local ('HEAD') and remote ('origin/master')

There is no 'pull' method currently.  See: https://github.com/astrocatalogs/astrocats/issues/67
