### PR TITLE
URL caching update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ The ['change-log' (below)](#changelog) in this file should summarize **all API c
     - Basic 'count' functionality to report the number of files and tasks in each catalog.
 - Added subcommands for git repositories in [astrocats/catalog/catalog.py](https://github.com/astrocatalogs/astrocats/blob/master/astrocats/catalog/catalog.py).
     - The `git-push` subcommand can now be used to add, commit and push all data files in each data repository.  This works in all installed catalogs.
-    - `git-clone`: clone all data repositories included in the `repos.json` input file.  **NOTE: the name given in the input file must match the github repository name for this to work.  If the directory name should be different from the github url, then it must be added manually.**
+    - `git-clone`: clone all data repositories included in the `repos.json` input file.  *NOTE: the name given in the input file must match the github repository name for this to work.  If the directory name should be different from the github url, then it must be added manually.*
     - 'git-reset' :
         - `git-reset-local`: reset the repository to the local HEAD, i.e. it runs `git reset --hard` in each data repository.
         - `git-reset-origin`: reset the repository to 'origin/master', i.e. it runs `git reset --hard origin/master` in each data repository.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,9 @@ The ['change-log' (below)](#changelog) in this file should summarize **all API c
         - `git-reset-origin`: reset the repository to 'origin/master', i.e. it runs `git reset --hard origin/master` in each data repository.
     - 'pull' : There is (currently) no pull command.  Instead, repositories must be pulled manually, or alternatively the `git-reset-[]` commands can be used to hard-reset.
     - `git-status` : print the status of the repo in each directory.
+- Loading cached/archived URLs, and the 'refresh' parameters.
+    - A new method `Catalog.load_url` has been added to take the place of `Catalog.load_cached_url` and `Task.load_archive` (both of which should now be considered deprecated), as well as some general functionality that has been written into individual tasks.
+    - The following command-line arguments and corresponding parameters have been deprecated: {`refresh`, `refresh-list`, `refresh-all`}
 - `astrocats/catalog/entry.py`
     - `Entry.add_alias` [new-function]
         - New method to add aliases to an existing entry after first 'cleaning' the alias name - in the same way as the entry names are cleaned by the containing catalog.  In this way, the stored aliases should be guaranteed (in general) to match the corresponding entry names (and naming styles).
@@ -46,6 +49,15 @@ The ['change-log' (below)](#changelog) in this file should summarize **all API c
 - `astrocats/catalog/source.py`
     - `Source.bibcode_from_url` [new-function]
         - Function extracts the Bibcode from an *ADS-URL* if possible.
+- `astrocats/catalog/catalog.py`
+    - `Catalog.load_cached_url` [DEPRECATED]
+        - Replaced by new method `load_url`
+    - `Catalog.load_url` [new-function]
+        - This method will load text data from either a URL or a pre-cached file of the data.
+        - The detailed behavior of the method depends on whether the code is being run in `archived` or `update` mode, and the settings for the particular task calling the method.
+- `astrocats/catalog/task.py`
+    - `Task.load_archive` [DEPRECATED]
+        - Replaced by functionality in `Catalog.load_url`.
 
 
 <a name='v0.2.0'>

--- a/astrocats/catalog/argshandler.py
+++ b/astrocats/catalog/argshandler.py
@@ -109,10 +109,6 @@ class ArgsHandler:
             '--archived', '-a', dest='archived',
             default=False, action='store_true',
             help='Always use task caches.')
-        import_pars.add_argument(
-            '--refresh-list', '-rl', dest='refresh_list',
-            default='', nargs='+',
-            help='Space-delimited list of caches to clear.')
 
         # Control which 'tasks' are executed
         # ----------------------------------

--- a/astrocats/catalog/argshandler.py
+++ b/astrocats/catalog/argshandler.py
@@ -102,10 +102,6 @@ class ArgsHandler:
             default=False, action='store_true',
             help='Only update catalog using live sources.')
         import_pars.add_argument(
-            '--refresh', '-r', dest='refresh',
-            default=False, action='store_true',
-            help='Ignore most task caches.')
-        import_pars.add_argument(
             '--archived', '-a', dest='archived',
             default=False, action='store_true',
             help='Always use task caches.')

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1172,6 +1172,13 @@ class Catalog:
               otherwise return None
 
         'update' mode:
+            * In update mode, try to compare URL to cached file.
+            * If URL fails, return None
+              (cannot update)
+            * If URL data matches cached data, return None
+              (dont need to update)
+            * If URL is different from data, return url data
+              (proceed with update)
 
         Arguments
         ---------
@@ -1238,12 +1245,27 @@ class Catalog:
             # Otherwise warn and return None
             self.log.warning(err_str)
             return None
-        # Otherwise, if url failed, return file
+
+        # Otherwise, if url failed, return file data
         elif url_txt is None:
             # If we are trying to update, but the url failed, then return None
             if self.args.update:
                 self.log.error("Cannot check for updates, url download failed.")
                 return None
+            # Otherwise, return file data
+            self.log.warning("URL download failed, using cached data.")
+            return file_txt
+
+        # Otherwise, if file failed, return url data (possible create cache)
+        elif file_txt is None:
+            # Write url_txt to new cache file
+            if write:
+                self.log.info("Writing `url_txt` to file '{}'.".format(
+                    cached_path))
+
+            return url_txt
+
+        # Here, both url_txt and file_txt exist
 
         if self.args.update:
             filemd5 = md5(file_txt.encode('utf-8')).hexdigest()

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1237,7 +1237,7 @@ class Catalog:
         # Check if we need to update this data
         # ------------------------------------
         # If both `url_txt` and `file_txt` exist and update mode check MD5
-        if file_txt is not None and args.update:
+        if file_txt is not None and self.args.update:
             from hashlib import md5
             url_md5 = md5(url_txt.encode('utf-8')).hexdigest()
             file_md5 = md5(file_txt.encode('utf-8')).hexdigest()
@@ -1258,9 +1258,9 @@ class Catalog:
 
     def _write_cache_file(self, data, filename, json_sort=None):
         # Sort json data first
-        if jsonsort is not None and filename.endswith('.json'):
+        if json_sort is not None and filename.endswith('.json'):
             json_data = json.loads(data)
-            json_data = list(sorted(json_data, key=lambda kk: kk[jsonsort]))
+            json_data = list(sorted(json_data, key=lambda kk: kk[json_sort]))
             data = json.dumps(json_data, indent=4, separators=(',', ': '))
         # Write txt to file
         with codecs.open(filename, 'w', encoding='utf8') as save_file:

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1343,6 +1343,7 @@ class Catalog:
 
         return url_txt
 
+
 def _get_task_priority(tasks, task_priority):
     """Get the task `priority` corresponding to the given `task_priority`.
 

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1271,6 +1271,11 @@ class Catalog:
         return url_txt
 
     def _write_cache_file(self, data, filename, json_sort=None):
+        # Make sure necessary directories exist
+        filename = os.path.abspath(filename)
+        base_path = os.path.split(filename)[0]
+        if not os.path.isdir(base_path):
+            os.makedirs(base_path)
         # Sort json data first
         if json_sort is not None and filename.endswith('.json'):
             json_data = json.loads(data)

--- a/astrocats/catalog/catalog.py
+++ b/astrocats/catalog/catalog.py
@@ -1255,6 +1255,7 @@ class Catalog:
             from hashlib import md5
             url_md5 = md5(url_txt.encode('utf-8')).hexdigest()
             file_md5 = md5(file_txt.encode('utf-8')).hexdigest()
+            self.log.debug("URL: '{}', File: '{}'.".format(url_md5, file_md5))
             # If the data is the same, no need to parse (update), return None
             if url_md5 == file_md5:
                 self.log.info("Skipping file '{}', no changes.".format(

--- a/astrocats/catalog/input/tasks.json
+++ b/astrocats/catalog/input/tasks.json
@@ -6,7 +6,7 @@
         "module": "catalog.tasks.test",
         "function": "do_test",
         "groups": ["meta"],
-        "repo": "input/test-input",
+        "repo": "input/catalog-test-input",
         "always_journal": true,
         "priority": 1
     },

--- a/astrocats/catalog/task.py
+++ b/astrocats/catalog/task.py
@@ -93,20 +93,6 @@ class Task():
                 ctask = ctask.replace('%pre', 'Loading')
         return ctask
 
-    def load_archive(self, args):
-        """Whether previously archived data should be loaded.
-        """
-        # If we're running in 'archived' mode, and only loading 'archived'
-        # things, then True
-        if (args.archived and self.name not in args.refresh_list):
-            return True
-        # For normal running, if we are not specifically refreshing this task,
-        # then True
-        if self.name not in args.refresh_list:
-            return True
-
-        return False
-
     def _get_repo_path(self, base_path):
         """
         """

--- a/astrocats/catalog/task.py
+++ b/astrocats/catalog/task.py
@@ -93,6 +93,20 @@ class Task():
                 ctask = ctask.replace('%pre', 'Loading')
         return ctask
 
+    def load_archive(self, args):
+        """Whether previously archived data should be loaded.
+        """
+        # If we're running in 'archived' mode, and only loading 'archived'
+        # things, then True
+        if (args.archived and self.name not in args.refresh_list):
+            return True
+        # For normal running, if we are not specifically refreshing this task,
+        # then True
+        if self.name not in args.refresh_list:
+            return True
+
+        return False
+
     def _get_repo_path(self, base_path):
         """
         """

--- a/astrocats/catalog/task.py
+++ b/astrocats/catalog/task.py
@@ -96,8 +96,10 @@ class Task():
     def load_archive(self, args):
         """Whether previously archived data should be loaded.
         """
-        # TEMPORARY METHOD
-        return args.archived
+        import warnings
+        warnings.warn("`Task.load_archive()` is deprecated!  "
+                      "`Catalog.load_url` handles the same functionality.")
+        return True
 
     def _get_repo_path(self, base_path):
         """

--- a/astrocats/catalog/task.py
+++ b/astrocats/catalog/task.py
@@ -96,6 +96,9 @@ class Task():
     def load_archive(self, args):
         """Whether previously archived data should be loaded.
         """
+        import warnings
+        warnings.warn("`Task.load_archive()` is deprecated!  "
+                      "`Catalog.load_url` handles the same functionality.")
         return True
 
     def _get_repo_path(self, base_path):

--- a/astrocats/catalog/task.py
+++ b/astrocats/catalog/task.py
@@ -96,6 +96,7 @@ class Task():
     def load_archive(self, args):
         """Whether previously archived data should be loaded.
         """
+        # TEMPORARY METHOD
         return args.archived
 
     def _get_repo_path(self, base_path):

--- a/astrocats/catalog/task.py
+++ b/astrocats/catalog/task.py
@@ -96,16 +96,7 @@ class Task():
     def load_archive(self, args):
         """Whether previously archived data should be loaded.
         """
-        # If we're running in 'archived' mode, and only loading 'archived'
-        # things, then True
-        if (args.archived and self.name not in args.refresh_list):
-            return True
-        # For normal running, if we are not specifically refreshing this task,
-        # then True
-        if self.name not in args.refresh_list:
-            return True
-
-        return False
+        return True
 
     def _get_repo_path(self, base_path):
         """

--- a/astrocats/catalog/tasks/test.py
+++ b/astrocats/catalog/tasks/test.py
@@ -42,9 +42,6 @@ def do_test(catalog):
 
     test_load_url(catalog)
 
-    return
-
-
     # Test repo path functions
     # ------------------------
     paths = catalog.PATHS.get_all_repo_folders()

--- a/astrocats/catalog/tasks/test.py
+++ b/astrocats/catalog/tasks/test.py
@@ -401,7 +401,6 @@ def test_load_url(catalog):
                                  write=False, update_mode=True)
     if test_data is not None:
         err_str = "Update mode should have returned None."
-        err_str += "\nInstead got '{}'".format(test_data)
         log_raise(err_str, log)
 
     # Use an invalid URL, but valid file
@@ -441,6 +440,7 @@ def test_load_url(catalog):
     catalog.load_cached_url('http://google.com', test_path)
 
     return
+
 
 def log_raise(err_str, log):
     log.error(err_str)

--- a/astrocats/catalog/tasks/test.py
+++ b/astrocats/catalog/tasks/test.py
@@ -28,9 +28,9 @@ FAKE_REDZ_2 = '0.987'
 
 def do_test(catalog):
     log = catalog.log
-    log.error("do_test()")
+    log.info("do_test()")
     task_str = catalog.get_current_task_str()
-    log.error("`task_str`: '{}'".format(task_str))
+    log.info("`task_str`: '{}'".format(task_str))
 
     if len(catalog.entries) != 0:
         raise RuntimeError("Run test only with empty catalog.")
@@ -41,28 +41,27 @@ def do_test(catalog):
                             catalog.PATHS.get_repo_output_folders()[0] +
                             'test.html')
 
-    log.error("In archive mode? " +
-              str(catalog.current_task.load_archive(catalog.args)))
+    log.info("`args.archived` = '{}', `current_task.archived` = '{}'".format(
+        catalog.args.archived, catalog.current_task.archived))
 
     # Test repo path functions
     # ------------------------
     paths = catalog.PATHS.get_all_repo_folders()
     for path in tq(paths, currenttask='Test tq progress bar.'):
         tprint('Test tprint.')
-        log.error(path)
+        log.debug(path)
     paths = catalog.PATHS.get_repo_input_folders()
     for path in pbar_strings(paths, desc='Test pbar_strings progress bar.'):
-        log.error(path)
+        log.debug(path)
     boneyard = catalog.PATHS.get_repo_boneyard()
-    log.error(boneyard)
+    log.debug(boneyard)
 
     # Create a Fake Entry, with some Fake Data
     # ----------------------------------------
     _first_event_first_source(catalog)
 
-    #
     log_str = "ADDING SECOND SOURCE"
-    log.error("\n\n{}\n{}\n{}\n\n".format("=" * 100, log_str, "=" * 100))
+    log.info("\n\n{}\n{}\n{}\n\n".format("=" * 100, log_str, "=" * 100))
 
     # Add new Data, from different source, to same fake entry
     # -------------------------------------------------------
@@ -90,11 +89,11 @@ def do_test(catalog):
     _first_event_second_source(catalog)
 
     # Test some utility functions
-    log.error("Preferred name for 2nd source: " +
+    log.debug("Preferred name for 2nd source: " +
               catalog.get_preferred_name(FAKE_ALIAS_2))
-    log.error("Entry exists? " +
+    log.debug("Entry exists? " +
               str(catalog.entry_exists(FAKE_ALIAS_2)))
-    log.error("Entry text: " + catalog.entries[FAKE_ALIAS_1].get_entry_text(
+    log.debug("Entry text: " + catalog.entries[FAKE_ALIAS_1].get_entry_text(
         os.path.join(outdir, filename + '.json')))
 
     # Third source is a duplicate that will be merged
@@ -104,10 +103,10 @@ def do_test(catalog):
     _second_event(catalog)
 
     # Delete name to test name re-addition in sanitize
-    for i, alias in enumerate(
+    for ii, alias in enumerate(
             catalog.entries[FAKE_ALIAS_5][ENTRY.ALIAS].copy()):
         if alias[QUANTITY.VALUE] == FAKE_ALIAS_5:
-            del catalog.entries[FAKE_ALIAS_1][ENTRY.ALIAS][i]
+            del catalog.entries[FAKE_ALIAS_1][ENTRY.ALIAS][ii]
             break
 
     return
@@ -118,10 +117,10 @@ def _first_event_first_source(catalog):
     """
     log = catalog.log
     # Add Entry to Catalog
-    log.error("Calling: ``add_entry('{}')``".format(FAKE_ALIAS_1))
+    log.info("Calling: ``add_entry('{}')``".format(FAKE_ALIAS_1))
     name = catalog.add_entry(FAKE_ALIAS_1)
-    log.error("\t `name`: '{}'".format(name))
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\t `name`: '{}'".format(name))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
     # Make sure entry exists
     if FAKE_ALIAS_1 not in catalog.entries:
         raise RuntimeError("`FAKE_ALIAS_1`: '{}' is not in entries".format(
@@ -133,11 +132,11 @@ def _first_event_first_source(catalog):
             ENTRY.NAME, stored_name, FAKE_ALIAS_1))
 
     # Add source to entry
-    log.error("Calling: ``add_source('{}')``".format(FAKE_BIBCODE_1))
+    log.info("Calling: ``add_source('{}')``".format(FAKE_BIBCODE_1))
     source = catalog.entries[name].add_source(
         name=FAKE_NAME_1, bibcode=FAKE_BIBCODE_1)
-    log.error("\t `source`: '{}'".format(source))
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\t `source`: '{}'".format(source))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
     # Make sure source alias is correct
     if source != '1':
         raise RuntimeError("Returned `source`: '{}' is wrong.".format(source))
@@ -145,10 +144,10 @@ def _first_event_first_source(catalog):
     check_source_1(catalog, name)
 
     # Add alias
-    log.error("Calling: ``add_quantity('alias', '{}', '{}')``".format(
+    log.info("Calling: ``add_quantity('alias', '{}', '{}')``".format(
         FAKE_ALIAS_2, source))
     catalog.entries[name].add_quantity(ENTRY.ALIAS, FAKE_ALIAS_2, source)
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
     # Make sure source alias is correct
     stored_aliases = catalog.entries[name][ENTRY.ALIAS]
     if ((len(stored_aliases) != 1 or
@@ -157,35 +156,35 @@ def _first_event_first_source(catalog):
         raise RuntimeError("Stored alias: '{}' looks wrong.".format(
             stored_aliases[0]))
 
-    log.error("Calling: ``add_quantity('redshift', '{}', '{}')``".format(
+    log.info("Calling: ``add_quantity('redshift', '{}', '{}')``".format(
         FAKE_REDZ_1, source))
     catalog.entries[name].add_quantity(
         ENTRY.REDSHIFT, FAKE_REDZ_1, source, kind='spectroscopic')
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     # Add a fake photometric observation
-    log.error("Calling: ``add_photometry(...)``")
+    log.info("Calling: ``add_photometry(...)``")
     catalog.entries[name].add_photometry(
         time='12345', magnitude='20.0', band='g', e_magnitude='0.01',
         telescope='OWELTMT', instrument='UltraCam', observer='I. M. Fake',
         observatory='Mt. Olympus', survey='Zeus Analog Sky Survey',
         source=source)
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     # Add a fake photometric observation with mangled data
-    log.error("Calling: ``add_photometry(...)``")
+    log.info("Calling: ``add_photometry(...)``")
     catalog.entries[name].add_photometry(
         time='oiasjdqw', magnitude='oihqwr', source=source)
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     # Add a fake photometric observation without required fields
-    log.error("Calling: ``add_photometry(...)``")
+    log.info("Calling: ``add_photometry(...)``")
     catalog.entries[name].add_photometry(e_magnitude='0.01')
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
-    log.error("Calling: ``journal_entries()``")
+    log.info("Calling: ``journal_entries()``")
     catalog.journal_entries()
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
     # Make sure the remaining stub looks right
     check_stub(catalog, name)
     return
@@ -194,10 +193,10 @@ def _first_event_first_source(catalog):
 def _first_event_second_source(catalog):
     log = catalog.log
 
-    log.error("Calling: ``add_entry('{}')``".format(FAKE_ALIAS_2))
+    log.info("Calling: ``add_entry('{}')``".format(FAKE_ALIAS_2))
     name = catalog.add_entry(FAKE_ALIAS_2)
-    log.error("\t `name`: '{}'".format(name))
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\t `name`: '{}'".format(name))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
     # Make sure the proper name is returned (instead of the alias)
     if name != FAKE_ALIAS_1:
         raise RuntimeError("Returned `name`: '{}' does not match '{}'".format(
@@ -205,26 +204,26 @@ def _first_event_second_source(catalog):
     # Make sure previous data was loaded
     check_source_1(catalog, name)
 
-    log.error("Calling: ``add_source('{}')``".format(FAKE_BIBCODE_2))
+    log.info("Calling: ``add_source('{}')``".format(FAKE_BIBCODE_2))
     source = catalog.entries[name].add_source(
         name=FAKE_NAME_2, bibcode=FAKE_BIBCODE_2)
-    log.error("\t `source`: '{}'".format(source))
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\t `source`: '{}'".format(source))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
-    log.error("Calling: ``add_quantity('alias', '{}', '{}')``".format(
+    log.info("Calling: ``add_quantity('alias', '{}', '{}')``".format(
         FAKE_ALIAS_3, source))
     catalog.entries[name].add_quantity(ENTRY.ALIAS, FAKE_ALIAS_3, source)
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
     check_source_2(catalog, name)
 
-    log.error("Calling: ``add_quantity('redshift', '{}', '{}')``".format(
+    log.info("Calling: ``add_quantity('redshift', '{}', '{}')``".format(
         FAKE_REDZ_2, source))
     catalog.entries[name].add_quantity(
         ENTRY.REDSHIFT, FAKE_REDZ_2, source, kind='spectroscopic')
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     # Add a fake spectral observation
-    log.error("Calling: ``add_spectrum(...)``")
+    log.info("Calling: ``add_spectrum(...)``")
     wavelengths = [str(1.0*x) for x in range(1000, 9000, 100)]
     fluxes = wavelengths
     errors = wavelengths
@@ -236,10 +235,10 @@ def _first_event_second_source(catalog):
         telescope='OWELTMT', instrument='MOSICE', observer='I. M. Fake',
         observatory='Mt. Everest', survey='Hillary Transient Factory',
         source=source, deredshifted=True)
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     # Add a duplicate of the above spectrum, shouldn't be added.
-    log.error("Calling: ``add_spectrum(...)``")
+    log.info("Calling: ``add_spectrum(...)``")
     wavelengths = [str(1.0*x) for x in range(1000, 9000, 100)]
     fluxes = wavelengths
     errors = wavelengths
@@ -248,11 +247,11 @@ def _first_event_second_source(catalog):
         u_errors='erg/s/cm^2/Angstrom', filename='my_spectrum.txt',
         time='12345',
         wavelengths=wavelengths, fluxes=fluxes, source=source)
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
-    log.error("Calling: ``journal_entries()``")
+    log.info("Calling: ``journal_entries()``")
     catalog.journal_entries()
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
     check_stub(catalog, name)
     return
 
@@ -260,29 +259,29 @@ def _first_event_second_source(catalog):
 def _first_event_third_source(catalog):
     log = catalog.log
 
-    log.error("Calling: ``new_entry('{}')``".format(FAKE_ALIAS_4))
+    log.info("Calling: ``new_entry('{}')``".format(FAKE_ALIAS_4))
     (name, source) = catalog.new_entry(FAKE_ALIAS_4, srcname=FAKE_NAME_2,
                                        bibcode=FAKE_BIBCODE_2)
-    log.error("\t `name`: '{}', `source`: '{}'".format(name, source))
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\t `name`: '{}', `source`: '{}'".format(name, source))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
-    log.error("Calling: ``add_quantity('alias', '{}', '{}')``".format(
+    log.info("Calling: ``add_quantity('alias', '{}', '{}')``".format(
         FAKE_ALIAS_1, source))
     catalog.entries[name].add_quantity(ENTRY.ALIAS, FAKE_ALIAS_1, source)
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     # Add erroroneous redshift, which should cause add_quantity below to fail.
-    log.error("Calling: ``add_error('{}', '{}', '{}')``".format(
+    log.info("Calling: ``add_error('{}', '{}', '{}')``".format(
         FAKE_BIBCODE_2, SOURCE.BIBCODE, ENTRY.REDSHIFT))
     catalog.entries[name].add_error(
         FAKE_BIBCODE_2, kind=SOURCE.BIBCODE, extra=ENTRY.REDSHIFT)
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
-    log.error("Calling: ``add_quantity('redshift', '{}', '{}')``".format(
+    log.info("Calling: ``add_quantity('redshift', '{}', '{}')``".format(
         FAKE_REDZ_2, source))
     catalog.entries[name].add_quantity(
         ENTRY.REDSHIFT, FAKE_REDZ_2, source, kind='spectroscopic')
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     return
 
@@ -290,27 +289,27 @@ def _first_event_third_source(catalog):
 def _second_event(catalog):
     log = catalog.log
 
-    log.error("Calling: ``new_entry('{}')``".format(FAKE_ALIAS_5))
+    log.info("Calling: ``new_entry('{}')``".format(FAKE_ALIAS_5))
     (name, source) = catalog.new_entry(FAKE_ALIAS_5, srcname=FAKE_NAME_2,
                                        bibcode=FAKE_BIBCODE_2)
-    log.error("\t `name`: '{}', `source`: '{}'".format(name, source))
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\t `name`: '{}', `source`: '{}'".format(name, source))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     # Add an orphan source
-    log.error("Calling: ``add_source('{}')``".format(FAKE_BIBCODE_3))
+    log.info("Calling: ``add_source('{}')``".format(FAKE_BIBCODE_3))
     source = catalog.entries[name].add_source(
         bibcode=FAKE_BIBCODE_3)
     source = catalog.entries[name].add_source(
         name=FAKE_NAME_3)
-    log.error("\t `source`: '{}'".format(source))
-    log.error("\n{}\n".format(repr(catalog.entries[name])))
+    log.debug("\t `source`: '{}'".format(source))
+    log.debug("\n{}\n".format(repr(catalog.entries[name])))
 
     return
 
 
 def check_source_1(catalog, name):
     stored_sources = catalog.entries[name][ENTRY.SOURCES]
-    print(stored_sources)
+    catalog.log.debug(str(stored_sources))
     if ((len(stored_sources) != 1 or
          stored_sources[0][SOURCE.NAME] != FAKE_NAME_1 or
          stored_sources[0][SOURCE.BIBCODE] != FAKE_BIBCODE_1)):


### PR DESCRIPTION
This pull-request contains enhancements for the way in which URLs are downloaded and cached, in addition to how `archived` mode operates.  The existing methods `Catalog.load_cached_url` and `Task.load_archive` provided _some_ of the framework necessary for the overall caching/archiving/updating functionality --- but this was somewhat incomplete, and the additional pieces were put together in the individual tasks that needed them.

Additionally, there was previously an error in the archived-mode logic which made normal imports run in the same way as archived mode.

The new machinery should consolidate everything cleanly.

**_BEFORE**_ this is merged:
- [x] Add temporary logic in `Catalog.load_cached_url` and `Task.load_archive` for backwards compatibility (e.g. with `Supernovae` catalog).
- [x] Create tests in the catalog test task
- [x] Add documentation in the change-log
- [x] Rebase changes from `origin/master`
- [ ] Run tests with the Supernovae catalog to make sure nothing is broken.  @guillochon 
- [x] Test implementations in Blackholes catalog.  @lzkelley
