### PR TITLE
Fix source checks

### DIFF
--- a/astrocats/catalog/entry.py
+++ b/astrocats/catalog/entry.py
@@ -461,13 +461,6 @@ class Entry(OrderedDict):
             raise CatDictError(
                 "{}: `source` must be provided!".format(self[self._KEYS.NAME]),
                 warn=True)
-        # Check that source is a list of integers
-        for x in source.split(','):
-            if not is_integer(x):
-                raise CatDictError(
-                    "{}: `source` is comma-delimited list of "
-                    " integers!".format(self[self._KEYS.NAME]),
-                    warn=True)
         # If this source/data is erroneous, skip it
         if self.is_erroneous(key_in_self, source):
             self._log.info("This source is erroneous, skipping")

--- a/astrocats/catalog/entry.py
+++ b/astrocats/catalog/entry.py
@@ -455,12 +455,6 @@ class Entry(OrderedDict):
 
     def _check_cat_dict_source(self, cat_dict_class, key_in_self, **kwargs):
         """Check that a source exists and that a quantity isn't erroneous."""
-        # Make sure that a source is given
-        source = kwargs.get(cat_dict_class._KEYS.SOURCE, None)
-        if source is None:
-            raise CatDictError(
-                "{}: `source` must be provided!".format(self[self._KEYS.NAME]),
-                warn=True)
         # If this source/data is erroneous, skip it
         if self.is_erroneous(key_in_self, source):
             self._log.info("This source is erroneous, skipping")

--- a/astrocats/catalog/entry.py
+++ b/astrocats/catalog/entry.py
@@ -455,6 +455,12 @@ class Entry(OrderedDict):
 
     def _check_cat_dict_source(self, cat_dict_class, key_in_self, **kwargs):
         """Check that a source exists and that a quantity isn't erroneous."""
+        # Make sure that a source is given
+        source = kwargs.get(cat_dict_class._KEYS.SOURCE, None)
+        if source is None:
+            raise CatDictError(
+                "{}: `source` must be provided!".format(self[self._KEYS.NAME]),
+                warn=True)
         # If this source/data is erroneous, skip it
         if self.is_erroneous(key_in_self, source):
             self._log.info("This source is erroneous, skipping")

--- a/astrocats/catalog/key.py
+++ b/astrocats/catalog/key.py
@@ -1,6 +1,6 @@
 """
 """
-from astrocats.catalog.utils import is_number
+from astrocats.catalog.utils import is_number, is_integer
 
 from past.builtins import basestring
 
@@ -137,6 +137,7 @@ class KeyCollection(object):
 
 class KEY_TYPES(KeyCollection):
     NUMERIC = 'numeric'
+    INTEGER = 'integer'
     TIME = 'time'
     STRING = 'string'
     BOOL = 'bool'
@@ -242,12 +243,17 @@ class Key(str):
         if not self.listable and is_list:
             return False
 
-        # `is_number` already checks for either list or single value
+        # `is_number` already checks for either list (comma separated) or single value (both str)
         if self.type == KEY_TYPES.NUMERIC and not is_number(val):
             return False
+
+        elif self.type == KEY_TYPES.INTEGER and not is_integer(val):
+            return False
+
         elif (self.type == KEY_TYPES.TIME and
               not is_number(val) and '-' not in val and '/' not in val):
             return False
+
         elif self.type == KEY_TYPES.STRING:
             # If its a list, check first element
             if is_list:
@@ -256,6 +262,7 @@ class Key(str):
             # Otherwise, check it
             elif not isinstance(val, basestring):
                 return False
+
         elif self.type == KEY_TYPES.BOOL:
             if is_list and not isinstance(val[0], bool):
                 return False

--- a/astrocats/catalog/source.py
+++ b/astrocats/catalog/source.py
@@ -30,7 +30,7 @@ class SOURCE(KeyCollection):
     ACKNOWLEDGMENT = Key('acknowledgment', KEY_TYPES.STRING, compare=False)
     REFERENCE = Key('reference', KEY_TYPES.STRING, compare=False)
     # Numbers
-    ALIAS = Key('alias', KEY_TYPES.NUMERIC, compare=False)
+    ALIAS = Key('alias', KEY_TYPES.INTEGER, compare=False)
     # Booleans
     SECONDARY = Key('secondary', KEY_TYPES.BOOL, compare=False)
     PRIVATE = Key('private', KEY_TYPES.BOOL, compare=False)

--- a/astrocats/catalog/spectrum.py
+++ b/astrocats/catalog/spectrum.py
@@ -53,7 +53,7 @@ class Spectrum(CatDict):
 
     def __init__(self, parent, **kwargs):
         self._REQ_KEY_SETS = [
-            [SPECTRUM.SOURCE, SPECTRUM.FILENAME],
+            [SPECTRUM.SOURCE],
             [SPECTRUM.U_FLUXES, SPECTRUM.FILENAME],
             [SPECTRUM.U_WAVELENGTHS, SPECTRUM.FILENAME],
         ]


### PR DESCRIPTION
In `Entry`, when adding new `CatDict` objects using `Entry._add_cat_dict`, the method `Entry._check_cat_dict_source` was requiring all `CatDict` to include a source.  This should not be the case, as `CatDict` can internally decide what parameters are required or not.  Some methods, like `add_source` circumvent these checks by manually adding the new catdict (in this case Source) without using the `_add_cat_dict` method.  This PR removes the source requirement from `_check_cat_dict_source`, which now returns false if the source is erroneous or private (these were the two additional checks previously) and otherwise returns True (even if no source exists).  The `_check_cat_dict_source()` method also checked to make sure that sources were comma-delimited integers.  To accomodate this, a new `KEY_TYPES.INTEGER` type has been added, and `SOURCE.ALIAS` is required to match this type.